### PR TITLE
Rework DeleteClientProfileCommandTest

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteClientProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClientProfileCommand.java
@@ -24,7 +24,7 @@ public class DeleteClientProfileCommand extends Command {
             + "Example: " + COMMAND_WORD + " n/Tan Wen Xuan";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Successfully deleted %1$s "
-            + " with the number: %2$s " + "and email: %3s!";
+            + " with the number: %2$s " + "and email: %3$s!";
     private final Name targetName;
 
     public DeleteClientProfileCommand(Name targetName) {
@@ -36,10 +36,7 @@ public class DeleteClientProfileCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        Person personToDelete = lastShownList.stream()
-                .filter(x -> x.isSamePerson(new Person(targetName)))
-                .findFirst()
-                .orElse(null);
+        Person personToDelete = model.getPersonByName(targetName);
 
         if (!lastShownList.contains(personToDelete)) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_INPUT);
@@ -47,7 +44,7 @@ public class DeleteClientProfileCommand extends Command {
 
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS,
-                personToDelete.getName(), personToDelete.getPhone()));
+                personToDelete.getName(), personToDelete.getPhone(), personToDelete.getEmail()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Name;
 
 /**
  * The API of the Model component.
@@ -75,6 +76,11 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Returns the person with the same name as {@code name} exists in the address book.
+     */
+    Person getPersonByName(Name name);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,8 +5,8 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * The API of the Model component.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Name;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -126,6 +127,19 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    /**
+     * Returns the person with the same name as {@code name} exists in the address book.
+     */
+    @Override
+    public Person getPersonByName(Name name) {
+        requireNonNull(name);
+        return this.getFilteredPersonList()
+                    .stream()
+                    .filter(person -> person.getName().equals(name))
+                    .findFirst()
+                    .orElse(null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,8 +11,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * Represents the in-memory model of the address book data.

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -37,8 +37,7 @@ public class Name {
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
-
-
+    
     @Override
     public String toString() {
         return fullName;

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -37,7 +37,6 @@ public class Name {
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
-    
     @Override
     public String toString() {
         return fullName;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -87,11 +87,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName())
-                && otherPerson.getPhone().equals(getPhone())
-                && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getProperty().equals(getProperty())
-                && otherPerson.getAppointment().equals(getAppointment());
+                && otherPerson.getName().equals(getName());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -38,7 +38,7 @@ public class Person {
         this.property = property;
         //  this.tags.addAll(tags);
     }
-
+    
     /**
      * Constructs a {@code Person} object with the specified name.
      * Initializes the phone number as {@code null}, sets the property to a default empty value,
@@ -46,6 +46,7 @@ public class Person {
      *
      * @param name The {@code Name} of the person. Must not be {@code null}.
      */
+    
     public Person(Name name) {
         this.name = name;
         this.phone = null;
@@ -88,7 +89,11 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getEmail().equals(getEmail())
+                && otherPerson.getProperty().equals(getProperty())
+                && otherPerson.getAppointment().equals(getAppointment());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -38,7 +38,6 @@ public class Person {
         this.property = property;
         //  this.tags.addAll(tags);
     }
-    
     /**
      * Constructs a {@code Person} object with the specified name.
      * Initializes the phone number as {@code null}, sets the property to a default empty value,
@@ -46,7 +45,6 @@ public class Person {
      *
      * @param name The {@code Name} of the person. Must not be {@code null}.
      */
-    
     public Person(Name name) {
         this.name = name;
         this.phone = null;

--- a/src/test/java/seedu/address/logic/commands/AddClientProfileTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClientProfileTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Name;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddClientProfileTest {
@@ -146,6 +147,11 @@ public class AddClientProfileTest {
 
         @Override
         public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+        
+        @Override
+        public Person getPersonByName(Name name) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddClientProfileTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClientProfileTest.java
@@ -22,8 +22,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddClientProfileTest {
@@ -149,7 +149,6 @@ public class AddClientProfileTest {
         public void setPerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }
-        
         @Override
         public Person getPersonByName(Name name) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.model.person.Name;
 
 /**
  * Contains helper methods for testing commands.
@@ -113,6 +114,16 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        final String[] splitName = person.getName().fullName.split("\\s+");
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredPersonList().size());
+    }
+    
+    public static void showPersonWithName(Model model, Name targetName) {
+        Person person = model.getPersonByName(targetName);
+        assertTrue(model.hasPerson(person));
+        
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -15,10 +15,10 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
-import seedu.address.model.person.Name;
 
 /**
  * Contains helper methods for testing commands.
@@ -119,11 +119,13 @@ public class CommandTestUtil {
 
         assertEquals(1, model.getFilteredPersonList().size());
     }
-    
+    /**
+     * Updates {@code model}'s filtered list to show only the person with the given {@code targetName} in the
+     * {@code model}'s address book.
+     */
     public static void showPersonWithName(Model model, Name targetName) {
         Person person = model.getPersonByName(targetName);
         assertTrue(model.hasPerson(person));
-        
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 

--- a/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
@@ -11,10 +11,10 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalNames;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Random;
+
+import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
@@ -13,8 +13,8 @@ import static seedu.address.testutil.TypicalPersons.getTypicalNames;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
 import java.util.List;
+import java.util.Random;
 
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
@@ -29,10 +29,10 @@ import seedu.address.model.person.Person;
  */
 public class DeleteClientProfileCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    
     private static final Name DO_NOT_EXIST_NAME = new Name("DO NOT EXIST NAME");
-    
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+
     @Test
     public void execute_validNameUnfilteredList_success() {
         Random random = new Random();
@@ -47,10 +47,10 @@ public class DeleteClientProfileCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
-        
+
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
-    
+
     @Test
     public void execute_invalidNameUnfilteredList_throwsCommandException() {
         DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(DO_NOT_EXIST_NAME);

--- a/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
@@ -3,24 +3,25 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonWithName;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalNames;
 
 import org.junit.jupiter.api.Test;
 
-//import seedu.address.commons.core.index.Index;
-//import seedu.address.logic.Messages;
+import java.util.Random;
+import java.util.List;
+
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-//import seedu.address.model.person.Name;
-//import seedu.address.model.person.Person;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -29,41 +30,46 @@ import seedu.address.model.UserPrefs;
 public class DeleteClientProfileCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
-    // change tests to use Person.name instead of index
-    /*
+    
+    private static final Name DO_NOT_EXIST_NAME = new Name("DO NOT EXIST NAME");
+    
     @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(ALICE.getName());
+    public void execute_validNameUnfilteredList_success() {
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 1);
 
-        String expectedMessage = String.format(DeleteClientProfileCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
-
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.deletePerson(personToDelete);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-
-    @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(new Name("DO_NOT_EXIST"));
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getPersonByName(typicalNames.get(randomIndex));
         DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(personToDelete.getName());
 
         String expectedMessage = String.format(DeleteClientProfileCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+                personToDelete.getName(), personToDelete.getPhone(), personToDelete.getEmail());
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+    
+    @Test
+    public void execute_invalidNameUnfilteredList_throwsCommandException() {
+        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(DO_NOT_EXIST_NAME);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_INPUT);
+    }
+
+    @Test
+    public void execute_validNameFilteredList_success() {
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 1);
+        showPersonWithName(model, typicalNames.get(randomIndex));
+
+        Person personToDelete = model.getPersonByName(typicalNames.get(randomIndex));
+        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(personToDelete.getName());
+
+        String expectedMessage = String.format(DeleteClientProfileCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                personToDelete.getName(), personToDelete.getPhone(), personToDelete.getEmail());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -73,18 +79,17 @@ public class DeleteClientProfileCommandTest {
     }
 
     @Test
-    public void execute_invalidNameFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_invalidNameFilteredList_success() {
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 2);
+        showPersonWithName(model, typicalNames.get(randomIndex));
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(typicalNames
+                                                                            .get(randomIndex + 1));
 
-        DeleteClientProfileCommand deleteCommand = new DeleteClientProfileCommand(ALICE.getName());
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_INPUT);
     }
-     */
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClientProfileCommandTest.java
@@ -79,7 +79,7 @@ public class DeleteClientProfileCommandTest {
     }
 
     @Test
-    public void execute_invalidNameFilteredList_success() {
+    public void execute_invalidNameFilteredList_throwsCommandException() {
         Random random = new Random();
         List<Name> typicalNames = getTypicalNames();
         int randomIndex = random.nextInt(typicalNames.size() - 2);

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -93,8 +93,10 @@ public class PersonTest {
                 + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail()
                 + ", appointment=" + ALICE.getAppointment()
-                + ", property=" + ALICE.getProperty() + "}";
-        //  + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
+                + ", property=" + ALICE.getProperty()
+                + ", email=" + ALICE.getEmail()
+                + "}";
+        // + ", address=" + ALICE.getAddress()
         //  + ", remark=" + ALICE.getRemark()
         //  + ", tags=" + ALICE.getTags() + "}"
         assertEquals(expected, ALICE.toString());

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -93,9 +93,7 @@ public class PersonTest {
                 + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail()
                 + ", appointment=" + ALICE.getAppointment()
-                + ", property=" + ALICE.getProperty()
-                + ", email=" + ALICE.getEmail()
-                + "}";
+                + ", property=" + ALICE.getProperty() + "}";
         // + ", address=" + ALICE.getAddress()
         //  + ", remark=" + ALICE.getRemark()
         //  + ", tags=" + ALICE.getTags() + "}"

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Name;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
@@ -69,5 +70,11 @@ public class TypicalPersons {
 
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+    
+    public static List<Name> getTypicalNames() {
+        return new ArrayList<>(Arrays.asList(ALICE.getName(), BENSON.getName(), CARL.getName(),
+                                            DANIEL.getName(), ELLE.getName(), FIONA.getName(),
+                                            GEORGE.getName()));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
@@ -71,7 +71,6 @@ public class TypicalPersons {
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }
-    
     public static List<Name> getTypicalNames() {
         return new ArrayList<>(Arrays.asList(ALICE.getName(), BENSON.getName(), CARL.getName(),
                                             DANIEL.getName(), ELLE.getName(), FIONA.getName(),


### PR DESCRIPTION
Abstracted the method
```
@Override
    public Person getPersonByName(Name name) {
        requireNonNull(name);
        return this.getFilteredPersonList()
                    .stream()
                    .filter(person -> person.getName().equals(name))
                    .findFirst()
                    .orElse(null);
    }
```
Updated the methods in `DeleteClientProfileCommandTest`
`execute_validNameUnfilteredList_success`
`execute_invalidNameUnfilteredList_throwsCommandException`
`execute_validNameFilteredList_success`
`execute_invalidNameFilteredList_throwsCommandException`
to accommodate to the deletion of client profiles by name

Updated other related classes as well