### PR TITLE
Remove `PREFIX_NAME` from parsers

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
@@ -6,9 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.List;
-
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Buyer;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Seller;
 
@@ -38,20 +39,21 @@ public class AppointmentCommand extends Command {
 
     public static final String MESSAGE_ADD_APPOINTMENT_SUCCESS = "Appointment scheduled for %1$s";
     public static final String MESSAGE_UPDATE_APPOINTMENT_SUCCESS = "Updated appointment scheduled for %1$s";
+    public static final String MESSAGE_INVALID_PERSON = "This person does not exist in the address book.";
 
-    private final Index index;
+    private final Name name;
     private final Appointment appointment;
 
     /**
      * Constructs an {@code AppointmentCommand} with the specified index and appointment details.
      *
-     * @param index The index of the person in the filtered person list.
+     * @param name The index of the person in the filtered person list.
      * @param appointment The new appointment to be added or updated.
      */
-    public AppointmentCommand(Index index, Appointment appointment) {
-        requireNonNull(index);
+    public AppointmentCommand(Name name, Appointment appointment) {
+        requireNonNull(name);
         requireNonNull(appointment);
-        this.index = index;
+        this.name = name;
         this.appointment = appointment;
     }
 
@@ -63,11 +65,11 @@ public class AppointmentCommand extends Command {
      * @throws CommandException If the index is invalid or the person cannot be found.
      */
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (!model.hasPersonOfName(name)) {
+            throw new CommandException(MESSAGE_INVALID_PERSON);
         }
-        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        Person personToEdit = model.getPersonByName(name);
         Person editedPerson;
 
         if (personToEdit instanceof Buyer buyer) {
@@ -104,7 +106,7 @@ public class AppointmentCommand extends Command {
         if (!(other instanceof AppointmentCommand)) {
             return false;
         }
-        AppointmentCommand a = (AppointmentCommand) other;
-        return index.equals(a.index) && appointment.equals(a.appointment);
+        AppointmentCommand otherAppointment = (AppointmentCommand) other;
+        return name.equals(otherAppointment.name) && appointment.equals(otherAppointment.appointment);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -51,32 +51,32 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Successfully edited %1$s!";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_INVALID_PERSON = "This person does not exist in the address book.";
 
-    private final Index index;
+    private final Name name;
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param name of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
-        requireNonNull(index);
+    public EditCommand(Name name, EditPersonDescriptor editPersonDescriptor) {
+        requireNonNull(name);
         requireNonNull(editPersonDescriptor);
 
-        this.index = index;
+        this.name = name;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (!model.hasPersonOfName(name)) {
+            throw new CommandException(MESSAGE_INVALID_PERSON);
         }
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person personToEdit = model.getPersonByName(name);
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
@@ -122,14 +122,14 @@ public class EditCommand extends Command {
         }
 
         EditCommand otherEditCommand = (EditCommand) other;
-        return index.equals(otherEditCommand.index)
+        return name.equals(otherEditCommand.name)
                 && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("index", index)
+                .add("name", name)
                 .add("editPersonDescriptor", editPersonDescriptor)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,12 +9,10 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/EditListingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditListingCommand.java
@@ -176,7 +176,7 @@ public class EditListingCommand extends Command {
         }
 
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, price, area, address, region);
+            return CollectionUtil.isAnyNonNull(name, price, area, address, region, sellerName);
         }
 
         public void setName(Name name) {

--- a/src/main/java/seedu/address/logic/parser/AddBuyersToListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyersToListingCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BUYER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/seedu/address/logic/parser/AddBuyersToListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyersToListingCommandParser.java
@@ -18,16 +18,10 @@ public class AddBuyersToListingCommandParser implements Parser<AddBuyersToListin
 
     @Override
     public AddBuyersToListingCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_BUYER);
-
-        // Check if the listing name (n/) is present
-        if (!argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddBuyersToListingCommand.MESSAGE_USAGE));
-        }
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BUYER);
 
         // Parse listing name
-        Name listingName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Name listingName = ParserUtil.parseName(argMultimap.getPreamble());
 
         // Parse buyer names with the "buyer/" prefix
         Set<Name> buyerNames = new HashSet<>();

--- a/src/main/java/seedu/address/logic/parser/AppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AppointmentCommandParser.java
@@ -8,8 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 
 import java.util.stream.Stream;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;

--- a/src/main/java/seedu/address/logic/parser/AppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AppointmentCommandParser.java
@@ -16,6 +16,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.Date;
 import seedu.address.model.appointment.From;
 import seedu.address.model.appointment.To;
+import seedu.address.model.person.Name;
 
 /**
  * Parses input arguments and creates a new AppointmentCommandParser object
@@ -30,12 +31,11 @@ public class AppointmentCommandParser implements Parser<AppointmentCommand> {
     public AppointmentCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_FROM, PREFIX_TO);
-        Index index;
+        Name name;
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AppointmentCommand.MESSAGE_USAGE),
-                    ive);
+            name = ParserUtil.parseName(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AppointmentCommand.MESSAGE_USAGE));
         }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_FROM, PREFIX_TO)) {
@@ -46,7 +46,7 @@ public class AppointmentCommandParser implements Parser<AppointmentCommand> {
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         From from = ParserUtil.parseFrom(argMultimap.getValue(PREFIX_FROM).get());
         To to = ParserUtil.parseTo(argMultimap.getValue(PREFIX_TO).get());
-        return new AppointmentCommand(index, new Appointment(date, from, to));
+        return new AppointmentCommand(name, new Appointment(date, from, to));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
@@ -21,26 +21,11 @@ public class DeleteAppointmentCommandParser implements Parser<DeleteAppointmentC
      * @throws ParseException If the user input does not conform to the expected format or the name is missing.
      */
     public DeleteAppointmentCommand parse(String args) throws ParseException {
-        String namePrefix = PREFIX_NAME.toString();
-        String trimmedArgs = args.trim();
-
-        // Check if the input contains the "n/" prefix
-        if (!trimmedArgs.startsWith(namePrefix)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteAppointmentCommand.MESSAGE_USAGE));
-        }
-
-        // Extract the name after "n/"
-        String nameString = trimmedArgs.substring(namePrefix.length()).trim();
-
-        // Check if the name is empty
-        if (nameString.isEmpty()) {
-            throw new ParseException(MISSING_CLIENT_NAME);
-        }
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args);
 
         try {
             // Parse the name and return the DeleteAppointmentCommand
-            Name name = ParserUtil.parseName(nameString);
+            Name name = ParserUtil.parseName(argumentMultimap.getPreamble());
             return new DeleteAppointmentCommand(name);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MISSING_CLIENT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.logic.commands.DeleteAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/DeleteClientProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteClientProfileCommandParser.java
@@ -19,26 +19,12 @@ public class DeleteClientProfileCommandParser implements Parser<DeleteClientProf
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteClientProfileCommand parse(String args) throws ParseException {
-        String namePrefix = PREFIX_NAME.toString();
-        String trimmedArgs = args.trim();
 
-        // Check if the input contains the "n/" prefix
-        if (!trimmedArgs.startsWith(namePrefix)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteClientProfileCommand.MESSAGE_USAGE));
-        }
-
-        // Extract the name after "n/"
-        String nameString = trimmedArgs.substring(namePrefix.length()).trim();
-
-        // Check if the name is empty
-        if (nameString.isEmpty()) {
-            throw new ParseException(MISSING_CLIENT_NAME);
-        }
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args);
 
         try {
             // Parse the name and return the DeleteClientProfileCommand
-            Name name = ParserUtil.parseName(nameString);
+            Name name = ParserUtil.parseName(argumentMultimap.getPreamble());
             return new DeleteClientProfileCommand(name);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/address/logic/parser/DeleteClientProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteClientProfileCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MISSING_CLIENT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.logic.commands.DeleteClientProfileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -33,10 +34,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG);
 
-        Index index;
+        Name name;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            name = ParserUtil.parseName(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
@@ -61,7 +62,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return new EditCommand(name, editPersonDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditListingCommandParser.java
@@ -4,13 +4,10 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AREA;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REGION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SELLER;
-
-import java.util.List;
 
 import seedu.address.logic.commands.EditListingCommand;
 import seedu.address.logic.commands.EditListingCommand.EditListingDescriptor;

--- a/src/main/java/seedu/address/logic/parser/EditListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditListingCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AREA;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REGION;
@@ -31,44 +32,21 @@ public class EditListingCommandParser implements Parser<EditListingCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_NAME, PREFIX_PRICE, PREFIX_AREA, PREFIX_ADDRESS, PREFIX_REGION, PREFIX_SELLER);
 
-        List<String> nameValues = argMultimap.getAllValues(PREFIX_NAME);
-
-        if (nameValues.size() > 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_PRICE).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_AREA).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_ADDRESS).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_REGION).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_SELLER).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PRICE, PREFIX_AREA, PREFIX_ADDRESS,
+                PREFIX_REGION, PREFIX_SELLER);
 
         Name currentListingName;
 
-        if (nameValues.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
-        }
-
         try {
-            currentListingName = ParserUtil.parseName(nameValues.get(0));
+            currentListingName = ParserUtil.parseName(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditListingCommand.MESSAGE_USAGE), pe);
         }
 
         EditListingDescriptor editListingDescriptor = new EditListingDescriptor();
-        if (nameValues.size() == 2) {
-            Name newListingName = ParserUtil.parseName(nameValues.get(1));
-            editListingDescriptor.setName(newListingName);
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editListingDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PRICE).isPresent()) {
             editListingDescriptor.setPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_PRICE).get()));

--- a/src/main/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParser.java
@@ -23,16 +23,10 @@ public class RemoveBuyersFromListingCommandParser implements Parser<RemoveBuyers
      */
     @Override
     public RemoveBuyersFromListingCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_BUYER);
-
-        // Check if listing name is present
-        if (!argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemoveBuyersFromListingCommand.MESSAGE_USAGE));
-        }
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BUYER);
 
         // Parse listing name
-        Name listingName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Name listingName = ParserUtil.parseName(argMultimap.getPreamble());
 
         // Parse buyer names
         Set<Name> buyerNames = new HashSet<>();

--- a/src/main/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BUYER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -110,7 +110,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         Name invalidName = new Name("aaaaaaaaaaaaaaa");
-        String deleteCommand = "delete " + PREFIX_NAME + invalidName;
+        String deleteCommand = "delete " + invalidName;
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_INPUT);
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 

--- a/src/test/java/seedu/address/logic/commands/AppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AppointmentCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.ArrayList;

--- a/src/test/java/seedu/address/logic/commands/AppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AppointmentCommandTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +13,6 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ModelStub;
@@ -20,6 +20,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.Date;
 import seedu.address.model.appointment.From;
 import seedu.address.model.appointment.To;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -44,16 +45,16 @@ public class AppointmentCommandTest {
     @Test
     public void constructor_nullAppointment_throwsNullPointerException() {
         // Test null appointment
-        assertThrows(NullPointerException.class, () -> new AppointmentCommand(INDEX_FIRST_PERSON, null));
+        assertThrows(NullPointerException.class, () -> new AppointmentCommand(ALICE.getName(), null));
     }
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
         // Arrange
         ModelStubWithPerson modelStub = new ModelStubWithPerson(new PersonBuilder().buildBuyer());
-        Index invalidIndex = Index.fromZeroBased(1);
+        Name invalidName = ALICE.getName();
 
-        AppointmentCommand command = new AppointmentCommand(invalidIndex, validAppointment);
+        AppointmentCommand command = new AppointmentCommand(invalidName, validAppointment);
 
         // Act & Assert
         assertThrows(CommandException.class, () -> command.execute(modelStub),
@@ -63,10 +64,10 @@ public class AppointmentCommandTest {
     @Test
     public void execute_validIndex_addAppointmentSuccess() throws Exception {
         // Arrange
-        Person personToEdit = new PersonBuilder().withName("Alice").buildBuyer();
+        Person personToEdit = ALICE;
         ModelStubWithPerson modelStub = new ModelStubWithPerson(personToEdit);
 
-        AppointmentCommand command = new AppointmentCommand(INDEX_FIRST_PERSON, validAppointment);
+        AppointmentCommand command = new AppointmentCommand(ALICE.getName(), validAppointment);
 
         // Act
         CommandResult result = command.execute(modelStub);
@@ -81,10 +82,10 @@ public class AppointmentCommandTest {
     @Test
     public void execute_validIndex_updatesPersonWithAppointment() throws Exception {
         // Arrange
-        Person personToEdit = new PersonBuilder().withName("Alice").buildBuyer();
+        Person personToEdit = ALICE;
         ModelStubWithPerson modelStub = new ModelStubWithPerson(personToEdit);
 
-        AppointmentCommand command = new AppointmentCommand(INDEX_FIRST_PERSON, validAppointment);
+        AppointmentCommand command = new AppointmentCommand(ALICE.getName(), validAppointment);
 
         // Act
         command.execute(modelStub);
@@ -118,6 +119,19 @@ public class AppointmentCommandTest {
                 throw new AssertionError("Target person not found in list.");
             }
             persons.set(index, editedPerson);
+        }
+
+        @Override
+        public boolean hasPersonOfName(Name name) {
+            return this.persons.stream()
+                    .anyMatch(person -> person.getName().equals(name));
+        }
+
+        @Override
+        public Person getPersonByName(Name name) {
+            return this.persons.stream()
+                    .filter(person -> person.getName().equals(name))
+                    .findFirst().orElse(null);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -18,6 +18,9 @@ import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalNames;
 
+import java.util.List;
+import java.util.Random;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
@@ -33,16 +36,13 @@ import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
-import java.util.List;
-import java.util.Random;
-
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new Listings());
     private static final Name VALID_NAME = ALICE.getName();
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new Listings());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -10,14 +10,16 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonWithName;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalNames;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.AddressBook;
@@ -26,9 +28,14 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Buyer;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+import java.util.List;
+import java.util.Random;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
@@ -36,12 +43,13 @@ import seedu.address.testutil.PersonBuilder;
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new Listings());
+    private static final Name VALID_NAME = ALICE.getName();
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Buyer editedPerson = new PersonBuilder().buildBuyer();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).withTags().build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(VALID_NAME, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -54,30 +62,29 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Person personToEdit = model.getPersonByName(VALID_NAME);
 
-        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        PersonBuilder personInList = new PersonBuilder(personToEdit);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).buildBuyer();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson)
                 .withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+        EditCommand editCommand = new EditCommand(VALID_NAME, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
                 new Listings());
-        expectedModel.setPerson(lastPerson, editedPerson);
+        expectedModel.setPerson(personToEdit, editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditCommand editCommand = new EditCommand(VALID_NAME, new EditPersonDescriptor());
+        Person editedPerson = model.getPersonByName(VALID_NAME);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -89,50 +96,56 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 1);
+        showPersonWithName(model, typicalNames.get(randomIndex));
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).buildBuyer();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        Person personToEdit = model.getPersonByName(typicalNames.get(randomIndex));
+        Person editedPerson = new PersonBuilder(personToEdit).withName(VALID_NAME_BOB).buildBuyer();
+        EditCommand editCommand = new EditCommand(personToEdit.getName(),
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
                 new Listings());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(personToEdit, editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getPersonByName(VALID_NAME);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(BENSON.getName(), descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 2);
+        Person editedPerson = model.getPersonByName(typicalNames.get(randomIndex + 1));
+        showPersonWithName(model, typicalNames.get(randomIndex));
 
-        // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder(personInList).build());
+        Person personToEdit = model.getPersonByName(typicalNames.get(randomIndex));
+
+        EditCommand editCommand = new EditCommand(personToEdit.getName(),
+                new EditPersonDescriptorBuilder(editedPerson).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+    public void execute_invalidNameUnfilteredList_failure() {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditCommand editCommand = new EditCommand(HOON.getName(), descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_INVALID_PERSON);
     }
 
     /**
@@ -141,24 +154,24 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        Random random = new Random();
+        List<Name> typicalNames = getTypicalNames();
+        int randomIndex = random.nextInt(typicalNames.size() - 2);
+        showPersonWithName(model, typicalNames.get(randomIndex));
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditCommand editCommand = new EditCommand(typicalNames.get(randomIndex + 1),
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_INVALID_PERSON);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(VALID_NAME, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(VALID_NAME, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -170,19 +183,18 @@ public class EditCommandTest {
         // different types -> returns false
         assertFalse(standardCommand.equals(new ClearCommand()));
 
-        // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        // different name -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(BOB.getName(), DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(ALICE.getName(), DESC_BOB)));
     }
 
     @Test
     public void toStringMethod() {
-        Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-        EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
-        String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
+        EditCommand editCommand = new EditCommand(VALID_NAME, editPersonDescriptor);
+        String expected = EditCommand.class.getCanonicalName() + "{name=" + VALID_NAME + ", editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -32,7 +32,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.TypicalPersons;
 
 import java.util.List;
 import java.util.Random;

--- a/src/test/java/seedu/address/logic/parser/AddBuyersToListingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddBuyersToListingCommandParserTest.java
@@ -24,8 +24,7 @@ public class AddBuyersToListingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() throws Exception {
-        String userInput = AddBuyersToListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME + " "
+        String userInput = VALID_LISTING_NAME + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_1 + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_2;
 
@@ -41,7 +40,7 @@ public class AddBuyersToListingCommandParserTest {
 
     @Test
     public void parse_missingListingName_throwsParseException() {
-        String userInput = AddBuyersToListingCommand.COMMAND_WORD + " "
+        String userInput = AddBuyersToListingCommand.COMMAND_WORD
                 + PREFIX_BUYER + VALID_BUYER_NAME_1;
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyersToListingCommand.MESSAGE_USAGE);
 
@@ -68,8 +67,7 @@ public class AddBuyersToListingCommandParserTest {
 
     @Test
     public void parse_multipleBuyersPresent_success() throws Exception {
-        String userInput = AddBuyersToListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME + " "
+        String userInput = VALID_LISTING_NAME + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_1 + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_2;
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,9 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.Arrays;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -73,8 +73,8 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().buildBuyer();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+                + ALICE.getName() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(ALICE.getName(), descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -64,7 +64,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_deleteClientProfile() throws Exception {
         DeleteClientProfileCommand command = (DeleteClientProfileCommand) parser.parseCommand(
-                DeleteClientProfileCommand.COMMAND_WORD + " " + PREFIX_NAME + ALICE.getName());
+                DeleteClientProfileCommand.COMMAND_WORD + " " + ALICE.getName());
         assertEquals(new DeleteClientProfileCommand(ALICE.getName()), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AppointmentCommandParserTest.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +16,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.Date;
 import seedu.address.model.appointment.From;
 import seedu.address.model.appointment.To;
+import seedu.address.model.person.Name;
 
 public class AppointmentCommandParserTest {
     private static final String VALID_DATE = "01-11-24";
@@ -24,18 +25,19 @@ public class AppointmentCommandParserTest {
     private static final String INVALID_DATE = "01/11/2024";
     private static final String INVALID_FROM = "9am";
     private static final String INVALID_TO = "10";
+    private static final Name VALID_NAME = ALICE.getName();
     private final AppointmentCommandParser parser = new AppointmentCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() throws Exception {
-        String userInput = INDEX_FIRST_PERSON.getOneBased() + " "
+        String userInput = ALICE.getName() + " "
                 + PREFIX_DATE + VALID_DATE + " "
                 + PREFIX_FROM + VALID_FROM + " "
                 + PREFIX_TO + VALID_TO;
 
         Appointment expectedAppointment = new Appointment(
                 new Date(VALID_DATE), new From(VALID_FROM), new To(VALID_TO));
-        AppointmentCommand expectedCommand = new AppointmentCommand(INDEX_FIRST_PERSON, expectedAppointment);
+        AppointmentCommand expectedCommand = new AppointmentCommand(ALICE.getName(), expectedAppointment);
 
         AppointmentCommand result = parser.parse(userInput);
         assertEquals(expectedCommand, result);
@@ -45,27 +47,36 @@ public class AppointmentCommandParserTest {
     public void parse_missingFields_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AppointmentCommand.MESSAGE_USAGE);
 
+        // missing name
         assertThrows(ParseException.class, () -> parser.parse(
-                INDEX_FIRST_PERSON.getOneBased() + " "
+               PREFIX_DATE + VALID_DATE
+               + PREFIX_FROM + VALID_FROM
+               + PREFIX_TO + VALID_TO), expectedMessage);
+
+        // missing date
+        assertThrows(ParseException.class, () -> parser.parse(
+                VALID_NAME + " "
                         + PREFIX_FROM + VALID_FROM + " "
                         + PREFIX_TO + VALID_TO), expectedMessage);
 
+        // missing from
         assertThrows(ParseException.class, () -> parser.parse(
-                INDEX_FIRST_PERSON.getOneBased() + " "
+                VALID_NAME + " "
                         + PREFIX_DATE + VALID_DATE + " "
                         + PREFIX_TO + VALID_TO), expectedMessage);
 
+        // missing to
         assertThrows(ParseException.class, () -> parser.parse(
-                INDEX_FIRST_PERSON.getOneBased() + " "
+                VALID_NAME + " "
                         + PREFIX_DATE + VALID_DATE + " "
                         + PREFIX_FROM + VALID_FROM), expectedMessage);
     }
 
     @Test
-    public void parse_invalidIndex_failure() {
+    public void parse_invalidName_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AppointmentCommand.MESSAGE_USAGE);
 
-        assertThrows(ParseException.class, () -> parser.parse("a "
+        assertThrows(ParseException.class, () -> parser.parse("$$" + " "
                 + PREFIX_DATE + VALID_DATE + " "
                 + PREFIX_FROM + VALID_FROM + " "
                 + PREFIX_TO + VALID_TO), expectedMessage);
@@ -73,7 +84,7 @@ public class AppointmentCommandParserTest {
 
     @Test
     public void parse_invalidDateFormat_failure() {
-        String userInput = INDEX_FIRST_PERSON.getOneBased() + " "
+        String userInput = VALID_NAME + " "
                 + PREFIX_DATE + INVALID_DATE + " "
                 + PREFIX_FROM + VALID_FROM + " "
                 + PREFIX_TO + VALID_TO;
@@ -83,7 +94,7 @@ public class AppointmentCommandParserTest {
 
     @Test
     public void parse_invalidFromFormat_failure() {
-        String userInput = INDEX_FIRST_PERSON.getOneBased() + " "
+        String userInput = VALID_NAME + " "
                 + PREFIX_DATE + VALID_DATE + " "
                 + PREFIX_FROM + INVALID_FROM + " "
                 + PREFIX_TO + VALID_TO;
@@ -93,7 +104,7 @@ public class AppointmentCommandParserTest {
 
     @Test
     public void parse_invalidToFormat_failure() {
-        String userInput = INDEX_FIRST_PERSON.getOneBased() + " "
+        String userInput = VALID_NAME + " "
                 + PREFIX_DATE + VALID_DATE + " "
                 + PREFIX_FROM + VALID_FROM + " "
                 + PREFIX_TO + INVALID_TO;

--- a/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
@@ -16,17 +16,18 @@ public class DeleteAppointmentCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, PREFIX_NAME + "Alice Pauline", new DeleteAppointmentCommand(ALICE.getName()));
+        assertParseSuccess(parser, "Alice Pauline", new DeleteAppointmentCommand(ALICE.getName()));
     }
 
     @Test
     public void parse_missingField_throwsParseException() {
-        assertParseFailure(parser, PREFIX_NAME.toString(), Messages.MISSING_CLIENT_NAME);
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteAppointmentCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "$$", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteAppointmentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
@@ -1,14 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteAppointmentCommand;
 
 public class DeleteAppointmentCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/DeleteClientProfileCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteClientProfileCommandParserTest.java
@@ -17,17 +17,18 @@ public class DeleteClientProfileCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, PREFIX_NAME + "Alice Pauline", new DeleteClientProfileCommand(ALICE.getName()));
+        assertParseSuccess(parser, "Alice Pauline", new DeleteClientProfileCommand(ALICE.getName()));
     }
 
     @Test
     public void parse_missingField_throwsParseException() {
-        assertParseFailure(parser, PREFIX_NAME.toString(), Messages.MISSING_CLIENT_NAME);
+        assertParseFailure(parser, PREFIX_NAME.toString(), String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteClientProfileCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "$$", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteClientProfileCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteClientProfileCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteClientProfileCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteClientProfileCommand;
 
 public class DeleteClientProfileCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -7,12 +7,15 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SECOND_BUYER_PASIR_RIS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -38,31 +41,23 @@ public class EditCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+    private static final Name TEST_NAME = new Name(VALID_NAME_AMY);
 
     private EditCommandParser parser = new EditCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
-
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, VALID_NAME_AMY, EditCommand.MESSAGE_NOT_EDITED);
 
-        // no index and no field specified
+        // no name and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
-        // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
-        // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "$$1", MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
@@ -70,13 +65,13 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, "Alice Pauline" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "Alice Pauline" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "Alice Pauline" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         //  assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "Alice Pauline" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
@@ -85,32 +80,30 @@ public class EditCommandParserTest {
         //  assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
+        assertParseFailure(parser, "Alice Pauline" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + NAME_DESC_AMY + EMAIL_DESC_AMY;
+        String userInput = VALID_NAME_AMY + PHONE_DESC_BOB + NAME_DESC_BOB + EMAIL_DESC_AMY;
         //  + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).build();
         // .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(TEST_NAME, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        String userInput = VALID_NAME_AMY + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(TEST_NAME, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -118,22 +111,21 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        String userInput = VALID_NAME_AMY + NAME_DESC_BOB;
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand expectedCommand = new EditCommand(TEST_NAME, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
+        userInput = VALID_NAME_AMY + PHONE_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(TEST_NAME, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
+        userInput = VALID_NAME_AMY + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(TEST_NAME, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
@@ -15,14 +14,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SECOND_BUYER_PASIR_RIS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/EditListingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditListingCommandParserTest.java
@@ -69,8 +69,8 @@ public class EditListingCommandParserTest {
 
     @Test
     public void parse_missingListingName_throwsParseException() {
-        String userInput = EditListingCommand.COMMAND_WORD +
-                PREFIX_PRICE + VALID_PRICE;
+        String userInput = EditListingCommand.COMMAND_WORD
+                + PREFIX_PRICE + VALID_PRICE;
         assertThrows(ParseException.class, () -> parser.parse(userInput),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/address/logic/parser/EditListingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditListingCommandParserTest.java
@@ -29,8 +29,7 @@ public class EditListingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() throws Exception {
-        String userInput = EditListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME_ONE + " "
+        String userInput = VALID_LISTING_NAME_ONE + " "
                 + PREFIX_NAME + VALID_LISTING_NAME_TWO + " "
                 + PREFIX_PRICE + VALID_PRICE + " "
                 + PREFIX_AREA + VALID_AREA + " "
@@ -55,8 +54,7 @@ public class EditListingCommandParserTest {
 
     @Test
     public void parse_partialFieldsPresent_success() throws Exception {
-        String userInput = EditListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME_ONE + " "
+        String userInput = VALID_LISTING_NAME_ONE + " "
                 + PREFIX_PRICE + VALID_PRICE;
 
         EditListingDescriptor descriptor = new EditListingDescriptor();
@@ -71,8 +69,8 @@ public class EditListingCommandParserTest {
 
     @Test
     public void parse_missingListingName_throwsParseException() {
-        String userInput = EditListingCommand.COMMAND_WORD + " "
-                + PREFIX_PRICE + VALID_PRICE;
+        String userInput = EditListingCommand.COMMAND_WORD +
+                PREFIX_PRICE + VALID_PRICE;
         assertThrows(ParseException.class, () -> parser.parse(userInput),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditListingCommand.MESSAGE_USAGE));
     }
@@ -80,7 +78,7 @@ public class EditListingCommandParserTest {
     @Test
     public void parse_noFieldsEdited_throwsParseException() {
         String userInput = EditListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME_ONE;
+                + VALID_LISTING_NAME_ONE;
         assertThrows(ParseException.class, () -> parser.parse(userInput),
                 EditListingCommand.MESSAGE_NOT_EDITED);
     }

--- a/src/test/java/seedu/address/logic/parser/ListingParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListingParserTest.java
@@ -69,14 +69,14 @@ public class ListingParserTest {
     @Test
     public void parseCommand_addBuyersToListing() throws Exception {
         Command command =
-                parser.parseCommand("addBuyersToListing n/Warton House buyer/John Doe");
+                parser.parseCommand("addBuyersToListing Warton House buyer/John Doe");
         assertEquals(AddBuyersToListingCommand.class, command.getClass());
     }
 
     @Test
     public void parseCommand_removeBuyersFromListing() throws Exception {
         Command command =
-                parser.parseCommand("removeBuyersFromListing n/Warton House buyer/John Doe");
+                parser.parseCommand("removeBuyersFromListing Warton House buyer/John Doe");
         assertEquals(RemoveBuyersFromListingCommand.class, command.getClass());
     }
 

--- a/src/test/java/seedu/address/logic/parser/ListingParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListingParserTest.java
@@ -38,7 +38,7 @@ public class ListingParserTest {
     @Test
     public void parseCommand_editListing() throws Exception {
         Command command =
-                parser.parseCommand("editListing n/Kent Ridge Condo n/Kent Ridge HDB");
+                parser.parseCommand("editListing Kent Ridge Condo n/Kent Ridge HDB");
         assertEquals(EditListingCommand.class, command.getClass());
     }
 

--- a/src/test/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveBuyersFromListingCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BUYER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -23,8 +24,7 @@ public class RemoveBuyersFromListingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() throws Exception {
-        String userInput = RemoveBuyersFromListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME + " "
+        String userInput = VALID_LISTING_NAME + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_1 + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_2;
 
@@ -40,8 +40,7 @@ public class RemoveBuyersFromListingCommandParserTest {
 
     @Test
     public void parse_multipleBuyers_success() throws Exception {
-        String userInput = RemoveBuyersFromListingCommand.COMMAND_WORD + " "
-                + PREFIX_NAME + VALID_LISTING_NAME + " "
+        String userInput = VALID_LISTING_NAME + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_1 + " "
                 + PREFIX_BUYER + VALID_BUYER_NAME_2;
 
@@ -52,12 +51,12 @@ public class RemoveBuyersFromListingCommandParserTest {
                 new Name(VALID_LISTING_NAME), expectedBuyerNames);
 
         RemoveBuyersFromListingCommand result = parser.parse(userInput);
-        assertEquals(expectedCommand, result);
+        assertTrue(expectedCommand.equals(result));
     }
 
     @Test
     public void parse_missingListingName_throwsParseException() {
-        String userInput = RemoveBuyersFromListingCommand.COMMAND_WORD + " "
+        String userInput = RemoveBuyersFromListingCommand.COMMAND_WORD
                 + PREFIX_BUYER + VALID_BUYER_NAME_1;
         assertThrows(ParseException.class, () -> parser.parse(userInput),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveBuyersFromListingCommand.MESSAGE_USAGE));


### PR DESCRIPTION
Commands that require `Client` or `Listing` names no longer need the `PREFIX_NAME`.

Only commands that add new `Client` or `Listing` requires the `n/` prefix