### PR TITLE
Fix logic for EditListingCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/listingcommands/EditListingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/listingcommands/EditListingCommand.java
@@ -97,7 +97,7 @@ public class EditListingCommand extends Command {
                 seller.orElse(listingToEdit.getSeller())
         );
 
-        if (!listingToEdit.isSameListing(editedListing) && model.hasListing(editedListing)) {
+        if (isIdentifierChanged(listingToEdit, editedListing) && model.canEditListing(listingToEdit, editedListing)) {
             throw new CommandException(MESSAGE_DUPLICATE_LISTING);
         }
 
@@ -122,6 +122,21 @@ public class EditListingCommand extends Command {
 
         return new Listing(updatedName, updatedAddress, updatedPrice, updatedArea, updatedRegion,
                 updatedSeller, listingToEdit.getBuyers());
+    }
+
+    /**
+     * Checks if the unique identifiers of a listing, specifically the name or address,
+     * have been modified in the edited version.
+     *
+     * @param listingToEdit The original listing before edits.
+     * @param editedListing The listing with potential edits.
+     * @return {@code true} if either the name or address of {@code editedListing} differs
+     *         from {@code listingToEdit}, indicating that the identifiers have changed.
+     *         Returns {@code false} otherwise.
+     */
+    private static boolean isIdentifierChanged(Listing listingToEdit, Listing editedListing) {
+        return !listingToEdit.getAddress().equals(editedListing.getAddress())
+                || !listingToEdit.getName().equals(editedListing.getName());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -151,14 +151,20 @@ public interface Model {
     boolean hasListingOfName(Name name);
 
     /**
+     * Determines if a listing can be edited without causing duplicate identifiers within the system.
+     * Checks if the edited listing's name or address matches any existing listing (excluding the original).
+     */
+    boolean canEditListing(Listing toEdit, Listing editedListing);
+
+    /**
      * Checks if the seller has a listing associated with it
      */
     boolean hasListingsForSeller(Person seller);
+
     /**
      * Checks if the buyer has a listing associated with it
      */
     boolean hasListingsForBuyer(Person buyer);
-
 
     // Returns the listing with the same name as {@code listing} exists in the address book.
     //Person getPersonByName(Name name);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -190,6 +190,20 @@ public class ModelManager implements Model {
                 .anyMatch(listing -> listing.getName().equals(name));
     }
 
+    /**
+     * Determines if a listing can be edited without causing duplicate identifiers within the system.
+     * Checks if the edited listing's name or address matches any existing listing (excluding the original).
+     */
+    @Override
+    public boolean canEditListing(Listing toEdit, Listing editedListing) {
+        requireAllNonNull(toEdit, editedListing);
+        return this.getFilteredListingList()
+                .stream()
+                .filter(listing -> !listing.equals(toEdit))
+                .anyMatch(currentListing -> editedListing.getName().equals(currentListing.getName())
+                    || editedListing.getAddress().equals(currentListing.getAddress()));
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/listing/Listing.java
+++ b/src/main/java/seedu/address/model/listing/Listing.java
@@ -107,7 +107,7 @@ public class Listing {
 
     /**
      * Checks if the given listing is the same listing as the current listing.
-     * Two listings are considered the same if they have the same address and seller.
+     * Two listings are considered the same if they have the same address or name.
      *
      * @param otherListing The other listing to compare.
      * @return True if the listings are the same, false otherwise.
@@ -117,10 +117,11 @@ public class Listing {
             return true;
         }
         return otherListing != null
-                && otherListing.address.equals(this.address)
-                && otherListing.name.equals(this.name);
+                && (otherListing.address.equals(this.address)
+                || otherListing.name.equals(this.name));
     }
 
+    // CHECK LOGIC FOR THIS
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -143,6 +143,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean canEditListing(Listing toEdit, Listing editedListing) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public boolean hasListingsForSeller(Person seller) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/model/listing/ListingTest.java
+++ b/src/test/java/seedu/address/model/listing/ListingTest.java
@@ -3,7 +3,6 @@ package seedu.address.model.listing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_PASIR_RIS;
 import static seedu.address.testutil.TypicalListings.PASIR_RIS;
 import static seedu.address.testutil.TypicalListings.TAMPINES;
 
@@ -22,27 +21,19 @@ public class ListingTest {
         // null -> returns false
         assertFalse(PASIR_RIS.isSameListing(null));
 
-        // same name, address, seller all other attributes different -> returns true
+        // same name and address all other attributes different -> returns true
         Listing editedListing = new ListingBuilder(PASIR_RIS).withArea(TAMPINES.getArea())
-                .withPrice(TAMPINES.getPrice()).build();
+                .withPrice(TAMPINES.getPrice()).withRegion(TAMPINES.getRegion())
+                .withSeller(TAMPINES.getSeller()).build();
         assertTrue(PASIR_RIS.isSameListing(editedListing));
 
-        // different name, all other attributes same -> returns false
+        // different name, all other attributes same -> returns true (address is the same)
         editedListing = new ListingBuilder(PASIR_RIS).withName(TAMPINES.getName()).build();
-        assertFalse(PASIR_RIS.isSameListing(editedListing));
+        assertTrue(PASIR_RIS.isSameListing(editedListing));
 
-        // different address, all other attributes same -> returns false
+        // different address, all other attributes same -> returns true (name is the same)
         editedListing = new ListingBuilder(PASIR_RIS).withAddress(TAMPINES.getAddress()).build();
-        assertFalse(PASIR_RIS.isSameListing(editedListing));
-
-        // different seller, all other attributes same -> returns false
-        editedListing = new ListingBuilder(PASIR_RIS).withSeller(TAMPINES.getSeller()).build();
-        assertFalse(PASIR_RIS.isSameListing(editedListing));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_PASIR_RIS + " ";
-        editedListing = new ListingBuilder(PASIR_RIS).withName(nameWithTrailingSpaces).build();
-        assertFalse(PASIR_RIS.isSameListing(editedListing));
+        assertTrue(PASIR_RIS.isSameListing(editedListing));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -74,7 +74,7 @@ class SampleDataUtilTest {
         Listing listing = sampleListings[0];
         assertEquals("RC4", listing.getName().fullName);
         assertEquals("134 Clementi Ave", listing.getAddress().value);
-        assertEquals("2000", listing.getPrice().getFormattedValue());
+        assertEquals("200000", listing.getPrice().getFormattedValue());
         assertEquals(100, listing.getArea().getArea());
         assertEquals(Region.WEST, listing.getRegion());
 

--- a/src/test/java/seedu/address/ui/ConfirmationDialogUiTest.java
+++ b/src/test/java/seedu/address/ui/ConfirmationDialogUiTest.java
@@ -32,7 +32,7 @@ public class ConfirmationDialogUiTest extends ApplicationTest {
         robot.write("seller n/Tester p/98765432 e/test@testing.com");
         robot.type(KeyCode.ENTER);
         robot.clickOn("#commandTextField");
-        robot.write("listing n/Testing Site price/1234 area/123 address/123 AVENUE "
+        robot.write("listing n/Testing Site price/123456 area/123 address/123 AVENUE "
                 + "region/east seller/Tester");
         robot.type(KeyCode.ENTER);
     }


### PR DESCRIPTION
Fix logic for EditListingCommand:
* Will only check for duplicate listings if there is an edit to the identifier of the listing.
* Iterate through the Listings to check for any duplicates, excluding the listing to edit.

TODO:
Check the logic for Listing equals method
Create more tests to test the changes in logic of the EditListingCommand